### PR TITLE
remove index item count validation - fail on item with valid index count

### DIFF
--- a/header.go
+++ b/header.go
@@ -155,10 +155,6 @@ func ReadPackageHeader(r io.Reader) (*Header, error) {
 		index := h.Indexes[x]
 		o := index.Offset
 
-		if index.ItemCount == 0 {
-			return nil, ErrBadIndexValueCount
-		}
-
 		switch index.Type {
 		case IndexDataTypeChar:
 			vals := make([]uint8, index.ItemCount)


### PR DESCRIPTION
Tested on a valid rpm file , appmon4j-agent-1.58.rpm , whilst opening this pkg , the index item count check failed even when the index item count is valid , I suggest to remove the index item count validation check 
