### PR TITLE
Add Modes() for getting file modes of the RPM contents

### DIFF
--- a/packagefile.go
+++ b/packagefile.go
@@ -249,6 +249,19 @@ func (c *PackageFile) Files() []string {
 	return files
 }
 
+// Modes returns the file mode of each file in the package. The order of the
+// returned modes matches the order returned by Files().
+func (c *PackageFile) Modes() []os.FileMode {
+	modes := c.Headers[1].Indexes.IntsByTag(RPMTAG_FILEMODES)
+
+	fileModes := make([]os.FileMode, len(modes))
+	for i := 0; i < len(modes); i++ {
+		fileModes[i] = os.FileMode(modes[i])
+	}
+
+	return fileModes
+}
+
 func (c *PackageFile) Summary() string {
 	return strings.Join(c.Headers[1].Indexes.StringsByTag(1004), "\n")
 }

--- a/packagefile_test.go
+++ b/packagefile_test.go
@@ -92,3 +92,44 @@ func TestChecksum(t *testing.T) {
 		}
 	}
 }
+
+func TestFileModes(t *testing.T) {
+	expectedModes := map[string]os.FileMode{
+		"/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7":           0644,
+		"/etc/yum.repos.d/epel-testing.repo":            0644,
+		"/etc/yum.repos.d/epel.repo":                    0644,
+		"/usr/lib/rpm/macros.d/macros.epel":             0644,
+		"/usr/lib/systemd/system-preset/90-epel.preset": 0644,
+		"/usr/share/doc/epel-release-7":                 0755,
+		"/usr/share/doc/epel-release-7/GPL":             0644,
+	}
+
+	path := "./testdata/epel-release-7-5.noarch.rpm"
+
+	p, err := OpenPackageFile(path)
+	if err != nil {
+		t.Fatalf("Error opening %s: %v", path, err)
+	}
+
+	names := p.Files()
+	modes := p.Modes()
+
+	if len(names) != len(modes) {
+		t.Fatal("Mismatched slice lenghts for Files (len=%v) and Modes (len=%v)", len(names), len(modes))
+	}
+
+	for i, name := range names {
+		mode := modes[i].Perm()
+
+		m, found := expectedModes[name]
+		if !found {
+			t.Errorf("unexpected file found in RPM: %v", name)
+			continue
+		}
+
+		if m != mode {
+			t.Errorf("expected %v but got %v for %v", m, mode, name)
+			continue
+		}
+	}
+}


### PR DESCRIPTION
This PR adds a `Modes()` method to `PackageFile` that returns the file mode of each file in the package.