### PR TITLE
Fix header indexes length

### DIFF
--- a/header.go
+++ b/header.go
@@ -70,7 +70,7 @@ func ReadPackageHeader(r io.Reader) (*Header, error) {
 	if h.Length > r_MaxHeaderSize {
 		return nil, ErrBadHeaderLength
 	}
-	if h.IndexCount*r_IndexHeaderLength > h.Length {
+	if h.IndexCount*r_IndexHeaderLength > r_MaxHeaderSize {
 		return nil, ErrBadIndexCount
 	}
 


### PR DESCRIPTION
Replace logical incorrect check with "fool proofing" check.

Current check is logical incorrect because header length describes
length of data section withOUT index section itself
and we cannot statically check it at the point where this check is at the moment.