### PR TITLE
FileInfo: Add Digest and Linkname methods

### DIFF
--- a/fileinfo.go
+++ b/fileinfo.go
@@ -10,14 +10,15 @@ import (
 //
 // FileInfo implements the os.FileInfo interface.
 type FileInfo struct {
-	name    string
-	size    int64
-	mode    os.FileMode
-	modTime time.Time
-	isDir   bool
-	owner   string
-	group   string
-	digest  string
+	name     string
+	size     int64
+	mode     os.FileMode
+	modTime  time.Time
+	isDir    bool
+	owner    string
+	group    string
+	digest   string
+	linkname string
 }
 
 // compile-time check that rpm.FileInfo implements os.FileInfo interface
@@ -65,6 +66,11 @@ func (f *FileInfo) Group() string {
 // Digest is the md5sum of a file in a RPM package
 func (f *FileInfo) Digest() string {
 	return f.digest
+}
+
+// Linkname is the link target of a link file in a RPM package
+func (f *FileInfo) Linkname() string {
+	return f.linkname
 }
 
 // Sys is required to implement os.FileInfo and always returns nil

--- a/fileinfo.go
+++ b/fileinfo.go
@@ -17,6 +17,7 @@ type FileInfo struct {
 	isDir   bool
 	owner   string
 	group   string
+	digest  string
 }
 
 // compile-time check that rpm.FileInfo implements os.FileInfo interface
@@ -59,6 +60,11 @@ func (f *FileInfo) Owner() string {
 // Group is the name of the owner group of a file in a RPM package
 func (f *FileInfo) Group() string {
 	return f.group
+}
+
+// Digest is the md5sum of a file in a RPM package
+func (f *FileInfo) Digest() string {
+	return f.digest
 }
 
 // Sys is required to implement os.FileInfo and always returns nil

--- a/packagefile.go
+++ b/packagefile.go
@@ -333,6 +333,7 @@ func (c *PackageFile) Files() []FileInfo {
 	times := c.GetInts(1, 1034)
 	owners := c.GetStrings(1, 1039)
 	groups := c.GetStrings(1, 1040)
+	digests := c.GetStrings(1, 1035)
 
 	c.files = make([]FileInfo, len(names))
 	for i := 0; i < len(names); i++ {
@@ -343,6 +344,7 @@ func (c *PackageFile) Files() []FileInfo {
 			modTime: time.Unix(times[i], 0),
 			owner:   owners[i],
 			group:   groups[i],
+			digest:  digests[i],
 		}
 	}
 

--- a/packagefile.go
+++ b/packagefile.go
@@ -334,17 +334,19 @@ func (c *PackageFile) Files() []FileInfo {
 	owners := c.GetStrings(1, 1039)
 	groups := c.GetStrings(1, 1040)
 	digests := c.GetStrings(1, 1035)
+	linknames := c.GetStrings(1, 1036)
 
 	c.files = make([]FileInfo, len(names))
 	for i := 0; i < len(names); i++ {
 		c.files[i] = FileInfo{
-			name:    dirs[ixs[i]] + names[i],
-			mode:    os.FileMode(modes[i]),
-			size:    sizes[i],
-			modTime: time.Unix(times[i], 0),
-			owner:   owners[i],
-			group:   groups[i],
-			digest:  digests[i],
+			name:     dirs[ixs[i]] + names[i],
+			mode:     os.FileMode(modes[i]),
+			size:     sizes[i],
+			modTime:  time.Unix(times[i], 0),
+			owner:    owners[i],
+			group:    groups[i],
+			digest:   digests[i],
+			linkname: linknames[i],
 		}
 	}
 

--- a/packagefile_test.go
+++ b/packagefile_test.go
@@ -138,6 +138,8 @@ func TestPackageFiles(t *testing.T) {
 		"", // digests field only populated for regular files
 		"03a55cfbbbfcdfc75fed8aeca5383fef12de4f019d5ff15c58f1e6581465007e",
 	}
+	// the test RPM has no links
+	linknames := []string{"", "", "", "", "", "", ""}
 
 	path := "./testdata/epel-release-7-5.noarch.rpm"
 
@@ -180,6 +182,10 @@ func TestPackageFiles(t *testing.T) {
 
 		if digest := fi.Digest(); digest != digests[i] {
 			t.Errorf("expected digest %v but got %v for %v", digests[i], digest, name)
+		}
+
+		if linkname := fi.Linkname(); linkname != linknames[i] {
+			t.Errorf("expected linkname %v but got %v for %v", linknames[i], linkname, name)
 		}
 	}
 }

--- a/packagefile_test.go
+++ b/packagefile_test.go
@@ -129,6 +129,15 @@ func TestPackageFiles(t *testing.T) {
 		time.Unix(1416932778, 0),
 		time.Unix(1416932629, 0),
 	}
+	digests := []string{
+		"028b9accc59bab1d21f2f3f544df5469910581e728a64fd8c411a725a82300c2",
+		"d9662befdbfb661b20b3af4a7feb34c6f58b4dc689bbeb0f29c73438015701b9",
+		"87d225d205a6263509508ac5cd4ca1bf1dc3e87960c9d305b3eb6c560f270297",
+		"6a43fe82450861a67ab673151972515069fe7fab44679f60345c826ac37e3e08",
+		"3de82a16cbc9eba0aa7c7edd7ef5e326a081afc8325aaf21ad11a68698b6b1d0",
+		"", // digests field only populated for regular files
+		"03a55cfbbbfcdfc75fed8aeca5383fef12de4f019d5ff15c58f1e6581465007e",
+	}
 
 	path := "./testdata/epel-release-7-5.noarch.rpm"
 
@@ -167,6 +176,10 @@ func TestPackageFiles(t *testing.T) {
 
 		if modtime := fi.ModTime(); modtime != modtimes[i] {
 			t.Errorf("expected modtime %v but got %v for %v", modtimes[i], modtime.Unix(), name)
+		}
+
+		if digest := fi.Digest(); digest != digests[i] {
+			t.Errorf("expected digest %v but got %v for %v", digests[i], digest, name)
 		}
 	}
 }


### PR DESCRIPTION
* Add a `Digest` method to the `FileInfo` struct to return the digest of the file. The digest is stored in the header at offset 1035.
* Add a ~`LinkTarget`~ `Linkname` method to the `FileInfo` struct to return the link target for links in the RPM. The link targets for an RPM are stored in the header at offset 1036.
* Update tests to verify new methods.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>

These methods are required for use in https://github.com/clearlinux/diva. It is simple enough to implement this on our own but it would be much cleaner (and allow us to read the RPM only once) if this library exposed this information.