### PR TITLE
Add some more RPM data

### DIFF
--- a/dependency.go
+++ b/dependency.go
@@ -15,6 +15,12 @@ const (
 	DepFlagEqual          = (1 << 3)
 	DepFlagLesserOrEqual  = (DepFlagEqual | DepFlagLesser)
 	DepFlagGreaterOrEqual = (DepFlagEqual | DepFlagGreater)
+	DepFlagPrereq         = (1 << 6)
+	DepFlagScriptPre      = (1 << 9)
+	DepFlagScriptPost     = (1 << 10)
+	DepFlagScriptPreUn    = (1 << 11)
+	DepFlagScriptPostUn   = (1 << 12)
+	DepFlagRpmlib         = (1 << 24)
 )
 
 // See: https://github.com/rpm-software-management/rpm/blob/master/lib/rpmds.h#L25

--- a/fileinfo.go
+++ b/fileinfo.go
@@ -5,6 +5,22 @@ import (
 	"time"
 )
 
+// File flags make up some attributes of files depending on how they were
+// specified in the rpmspec
+const (
+	FileFlagNone      = 0
+	FileFlagConfig    = (1 << 0)  // %%config
+	FileFlagDoc       = (1 << 1)  // %%doc
+	FileFlagIcon      = (1 << 2)  // %%donotuse
+	FileFlagMissingOk = (1 << 3)  // %%config(missingok)
+	FileFlagNoReplace = (1 << 4)  // %%config(noreplace)
+	FileFlagGhost     = (1 << 6)  // %%ghost
+	FileFlagLicense   = (1 << 7)  // %%license
+	FileFlagReadme    = (1 << 8)  // %%readme
+	FileFlagPubkey    = (1 << 11) // %%pubkey
+	FileFlagArtifact  = (1 << 12) // %%artifact
+)
+
 // A FileInfo describes a file in a RPM package and is returned by
 // packagefile.Files.
 //
@@ -15,6 +31,7 @@ type FileInfo struct {
 	mode     os.FileMode
 	modTime  time.Time
 	isDir    bool
+	flags    int64
 	owner    string
 	group    string
 	digest   string
@@ -50,7 +67,11 @@ func (f *FileInfo) ModTime() time.Time {
 
 // IsDir returns true if a file is a directory in a RPM package
 func (f *FileInfo) IsDir() bool {
-	return f.isDir
+	return f.mode.IsDir()
+}
+
+func (f *FileInfo) Flags() int64 {
+	return f.flags
 }
 
 // Owner is the name of the owner of a file in a RPM package

--- a/packagefile.go
+++ b/packagefile.go
@@ -319,6 +319,22 @@ func (c *PackageFile) Obsoletes() []Dependency {
 	return c.dependencies(5043, 1114, 1090, 1115)
 }
 
+func (c *PackageFile) Suggests() []Dependency {
+	return c.dependencies(5059, 5051, 5049, 5050)
+}
+
+func (c *PackageFile) Enhances() []Dependency {
+	return c.dependencies(5061, 5057, 5055, 5056)
+}
+
+func (c *PackageFile) Recommends() []Dependency {
+	return c.dependencies(5058, 5048, 5046, 5047)
+}
+
+func (c *PackageFile) Supplements() []Dependency {
+	return c.dependencies(5060, 5051, 5052, 5053)
+}
+
 // Files returns file information for each file that is installed by this RPM
 // package.
 func (c *PackageFile) Files() []FileInfo {

--- a/packagefile.go
+++ b/packagefile.go
@@ -332,6 +332,7 @@ func (c *PackageFile) Files() []FileInfo {
 	modes := c.GetInts(1, 1030)
 	sizes := c.GetInts(1, 1028)
 	times := c.GetInts(1, 1034)
+	flags := c.GetInts(1, 1037)
 	owners := c.GetStrings(1, 1039)
 	groups := c.GetStrings(1, 1040)
 	digests := c.GetStrings(1, 1035)
@@ -344,6 +345,7 @@ func (c *PackageFile) Files() []FileInfo {
 			mode:     fileModeFromInt64(modes[i]),
 			size:     sizes[i],
 			modTime:  time.Unix(times[i], 0),
+			flags:    flags[i],
 			owner:    owners[i],
 			group:    groups[i],
 			digest:   digests[i],


### PR DESCRIPTION
There was some flags and dependency types that exist as RPM tags, but where not defined in this library. This PR imports more dependency flags, adds support for file flags (such as `%ghost`) and completes the definitions for dependencies, adding methods for suggests, enhances, recommends and supplements.