### PR TITLE
developer/development.ini.example to development.ini

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,18 @@
 
 A native implementation of the RPM file specification in Go.
 
-	$ go get github.com/cavaliercoder/go-rpm
+	$ go get davidallenarteaga@arteagainc.com/cavaliercoder/go-rpm/devel/development.ini.example to development.ini
 
+$ docker buildx build --platform linux/arm/v7 -t amouat/arch-test:armv7 .
+…
+$ docker push amouat/arch-test:armv7
+…
+$ docker buildx build -t amouat/arch-test:amd64 .
+…
+$ docker push amouat/arch-v7
 
 The go-rpm package aims to enable cross-platform tooling for yum/dnf/rpm
-written in Go (E.g. [y10k](https://github.com/cavaliercoder/y10k)).
+written in Go (E.g. [y10k](https://davidallenarteaga@arteagainc.com/cavaliercoder/y10k)).
 
 Initial goals include like-for-like implementation of existing rpm ecosystem
 features such as:
@@ -17,6 +24,106 @@ features such as:
 
 ```go
 package main
+dist: bionic
+sudo: required
+
+install:
+  - docker run --rm --privileged linuxkit/binfmt:v0.8
+  - docker run --name buildkit --rm -d --privileged -p 1234:1234 $REPO_SLUG_ORIGIN --debug --addr tcp://0.0.0.0:1234 --oci-worker-gc=false
+  - sudo docker cp buildkit:/usr/bin/buildctl /usr/bin/
+  - export BUILDKIT_HOST=tcp://0.0.0.0:1234
+
+after_failure:
+  - docker logs buildkit
+  - sudo dmesg
+
+env:
+  global:
+    - PLATFORMS="linux/amd64,linux/arm/v7,linux/arm64,linux/s390x,linux/ppc64le"
+    - PREFER_BUILDCTL="1"
+
+jobs:
+  include:
+    - stage: building
+      name: "Build"
+      script: ./hack/login_ci_cache && ./hack/build_ci_first_pass
+    - stage: testing
+      name: "Client integration tests"
+      script: 
+        - TESTPKGS=./client ./hack/test integration
+        - TESTPKGS=./cmd/buildctl ./hack/test integration
+    - script:
+       - ./hack/lint
+       - SKIP_INTEGRATION_TESTS=1 ./hack/test integration gateway
+       - ./hack/validate-vendor
+       - ./hack/validate-generated-files
+       - TESTPKGS=./frontend ./hack/test
+      name: "Unit Tests & Lint & Vendor & Proto"
+    - script:
+       - TESTPKGS=./frontend/dockerfile TESTFLAGS='-v --parallel=6' ./hack/test
+      name: "Dockerfile integration tests"
+    - script: TESTPKGS=./frontend/dockerfile ./hack/test dockerfile
+      name: "External Dockerfile tests"
+    - script: RUNC_PLATFORMS=$PLATFORMS PLATFORMS="${PLATFORMS},darwin/amd64,windows/amd64" ./hack/cross
+      name: "Cross"
+    - script: ./hack/images local $REPO_SLUG_TARGET
+      name: "Build image"
+      if: type == cron
+    - stage: deploy
+      script: skip
+      name: "Deploy"
+      if: type != pull_request
+      deploy:
+        - provider: script
+          script: ./hack/images master $REPO_SLUG_TARGET push
+          on:
+            repo: moby/buildkit
+            branch: master
+            condition: $TRAVIS_EVENT_TYPE != "cron"
+        - provider: script
+          script: ./hack/images $TRAVIS_TAG $REPO_SLUG_TARGET push && PLATFORMS="${PLATFORMS},darwin/amd64,windows/amd64" ./hack/release-tar $TRAVIS_TAG release-out
+          on:
+            repo: moby/buildkit
+            tags: true
+            condition: $TRAVIS_TAG =~ ^v[0-9]
+        - provider: releases
+          api_key:
+            secure: "hA0L2F6O1MLEJEbUDzxokpO6F6QrAIkltmVG3g0tTAoVj1xtCOXSmH3cAnVbFYyOz9q8pa/85tbpyEEIHVlqvWk2a5/QS16QaBW6XxH+FiZ3oQ44JbtpsjpmBFxdhfeFs8Ca6Nj29AOtDx21HHWsZKlBZFvC4Ubc05AM1rgZpJyZVDvYsjZIunc8/CPCbvAAp6RLnLHxAYXF+TQ7mAZP2SewsW/61nPjPIp2P4d93CduA9kUSxtC/1ewmU2T9Ak2X1Nw2ecPTonGjO51xNa6Ebo1hsbsRt5Krd1IR5rSkgXqLrhQO+19J3sUrQr2p8su6hCTKXR5TQz9L5C9VG8T3yOLbA7/FKBndWgBCm7EB7SezhFkm91e3Phkd/Hi5PF4ZKUSKyOYORHpoeg7ggBXaQF5r0OolqvNjxe7EhE+zlUIqnk5eprVrXT8H1QDF0Jg7pfdqVV9AIZO6i+e+1wOVDaP6K6tiWGdkRFH0wahcucZ/8xVoa8JVNZKke2mMCuLGsNWcN4DeLhkxa6giw3tkqbnY+eTYcW/PyVFMAVsZ8rOjQu4u4mm82FYBI7UywWQJTReD1LO2ibxHk74nwtyauX7KsCPFh2CA27DKlsQ1/xkjaCpE6vduzKzPj2DSHp6tKjxn2edPWRI+/4JxLD6KUFX1f1KqD0pKy/qVsZhEPI="
+          file: release-out/**/*
+          skip_cleanup: true
+          file_glob: true
+          on:
+           repo: moby/buildkit
+           tags: true
+           condition: $TRAVIS_TAG =~ ^v[0-9]
+        - provider: script
+          script: ./frontend/dockerfile/cmd/dockerfile-frontend/hack/release master mainline $DF_REPO_SLUG_TARGET push
+          on:
+            repo: moby/buildkit
+            branch: master
+            condition: $TRAVIS_EVENT_TYPE != "cron"
+        - provider: script
+          script: ./frontend/dockerfile/cmd/dockerfile-frontend/hack/release master experimental $DF_REPO_SLUG_TARGET push
+          on:
+            repo: moby/buildkit
+            branch: master
+            condition: $TRAVIS_EVENT_TYPE != "cron"
+        - provider: script
+          script: ./frontend/dockerfile/cmd/dockerfile-frontend/hack/release tag $TRAVIS_TAG $DF_REPO_SLUG_TARGET push
+          on:
+            repo: moby/buildkit
+            tags: true
+            condition: $TRAVIS_TAG =~ ^dockerfile/[0-9]
+        - provider: script
+          script: ./frontend/dockerfile/cmd/dockerfile-frontend/hack/release daily _ $DF_REPO_SLUG_TARGET push
+          on:
+            repo: moby/buildkit
+            branch: master
+            condition: $TRAVIS_EVENT_TYPE == "cron"
+      
+
+before_deploy:
+  - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 
 import (
 	"fmt"


### PR DESCRIPTION
When set to true, GitHub cancels all in-progress jobs if any matrix job fetcher. Default: true

jobs.<job_id>.strategy.max-parallel
The maximum number of jobs that can run simultaneously when using a matrix job strategy. By default, GitHub will maximize the number of jobs run in parallel depending on the available runners on GitHub-hosted virtual machines.

strategy:
  max-parallel: 2
jobs.<job_id>.continue-on-error
Prevents a workflow run from failing when a job fails. Set to true to allow a workflow run to pass when this job fails.

Run example prevent a specific sailing matrix job from failing a workflow run
You can allow specific jobs in a job matrix to fail without failing the workflow run. For example, if you wanted to only allow an experimental job with node set to 33 to fail without failing the workflow run.